### PR TITLE
Add Public IPv6 DNS server to resolv.conf

### DIFF
--- a/export-image/02-network/files/resolv.conf
+++ b/export-image/02-network/files/resolv.conf
@@ -1,1 +1,2 @@
 nameserver 8.8.8.8
+nameserver 2001:4860:4860::8888


### PR DESCRIPTION
I was running a wlanpi on a network with working IPv6 but not IPv4 and I couldn't use the `publicip6` function. I realized that this was due to a lack of an IPv6 DNS server. This pull request would add the IPv6 cousin of 8.8.8.8 to resolv.conf so that if there is only IPv6 connectivity, more functions will work.