### PR TITLE
Increase swiotlib size to 64MB in cmdline.txt to support Intel AX210

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait
+console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait swiotlb=65536


### PR DESCRIPTION
Increasing swiotlb size because the recommended Intel AX210 PCIe M.2 adapter causes buffer overflows when using the default size.

Example of the error this fixes:
![image](https://github.com/WLAN-Pi/pi-gen/assets/6666925/9c63aeb1-a799-422a-b55f-b7cdf85a4c53)
