### PR TITLE
Add SHA256 checksum creation to image build process

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -67,11 +67,22 @@ jobs:
           sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           sudo ./build-docker.sh -v ${{ github.event.inputs.version-bump }}
 
+      - name: Generate checksum
+        id: generate-checksum
+        run: |
+          cd deploy; for file in *.zip; do echo $(sha256sum --binary $file) > "${file}.sha256"; done; cd ../
+
       - name: Upload image
         uses: actions/upload-artifact@v3
         with:
           name: wlanpi-nightly-release-${{ steps.build-image.outputs.version }}
           path: deploy/*.zip
+
+      - name: Upload image checksum
+        uses: actions/upload-artifact@v3
+        with:
+          name: wlanpi-nightly-release-${{ steps.build-image.outputs.version }}-sha256
+          path: deploy/*.sha256
 
       - name: Upload image info
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Generate checksum
         id: generate-checksum
         run: |
-          cd deploy; for file in *.zip; do echo $(sha256sum --binary $file) > "${file}.sha256"; done; cd ../
+          cd deploy; for file in *.zip; do sha256sum --binary $file | sudo tee "${file}.sha256"; done; cd ../
 
       - name: Upload image
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Adds a step to create a SHA256 checksum of the built image and upload it along side the image, to allow verification of successful upload and download for end users.